### PR TITLE
Fix subscription API call

### DIFF
--- a/lib/exyt/request.ex
+++ b/lib/exyt/request.ex
@@ -32,13 +32,12 @@ defmodule Exyt.Request do
       query: query
     ]
 
-    HTTPotion.request(method, url, options)
-    |> parse_response()
+    HTTPotion.request(method, url, options) |> parse_response()
   end
 
   defp process_headers(%Client{token: token}) do
     %{}
-    |> Map.put("Authorization", "BEARER #{token.access_token}")
+    |> Map.put(:Authorization, "Bearer #{token.access_token}")
     |> Map.merge(@default_headers)
     |> Map.to_list()
   end
@@ -52,7 +51,7 @@ defmodule Exyt.Request do
     {:ok,
       %Exyt.Response{
         status_code: response.status_code,
-        body: response.body,
+        body: Poison.Parser.parse!(response.body),
         headers: response.headers.hdrs
       }
     }

--- a/lib/exyt/response.ex
+++ b/lib/exyt/response.ex
@@ -21,8 +21,8 @@ defmodule Exyt.Response do
   def new(code, headers, body) do
     %__MODULE__{
       status_code: code,
-      headers: headers,
-      body: body
+      headers:     headers,
+      body:        body
     }
   end
 end

--- a/lib/exyt/subscription.ex
+++ b/lib/exyt/subscription.ex
@@ -15,9 +15,9 @@ defmodule Exyt.Subscription do
     * `part` - A combination of the following, "snippet", "contentDetails", "id", "subscriberSnippet"
 
   """
-  @spec list(Client.t, binary) :: {:ok, Response.t} | {:error, binary}
-  def list(%Client{} = client, part \\ @part) do
-    query = %{mine: true, part: part}
+  @spec list(Client.t, map) :: {:ok, Response.t} | {:error, binary}
+  def list(%Client{} = client, options \\ %{}) do
+    query = %{mine: true, part: "snippet"}
 
     Request.request(:get, client, "/subscriptions", query)
   end

--- a/test/exyt/subscription_test.exs
+++ b/test/exyt/subscription_test.exs
@@ -17,7 +17,9 @@ defmodule Exyt.SubscriptionTest do
   describe "list" do
     test "returns successful response", %{client: client, bypass: bypass} do
       Bypass.expect_once bypass, "GET", "/subscriptions", fn conn ->
-        assert conn.query_string == "mine=true&part=snippet%2CContentDetails"
+        assert List.keyfind(conn.req_headers, "authorization", 0) == {"authorization", "Bearer 1234"}
+        assert conn.request_path == "/subscriptions"
+        assert conn.query_string == "mine=true&part=snippet"
 
         json_response(conn, 200, "subscriptions.json")
       end
@@ -25,7 +27,7 @@ defmodule Exyt.SubscriptionTest do
       {:ok, response} = Subject.list(client)
 
       assert 200 == response.status_code
-      assert Poison.Parser.parse!(response.body)
+      assert Enum.count(response.headers) > 0
     end
   end
 end


### PR DESCRIPTION
This PR fixes the basic subscription API call, fetches user's subscriptions for now

* fix setting of `Authorization` header, calls API endpoint with fixed query string for now
* adjust subscription test to check properties
* parse JSON response body in `Exyt.Response`