### PR TITLE
Refactor / extend subscription function parameters

### DIFF
--- a/lib/exyt/subscription.ex
+++ b/lib/exyt/subscription.ex
@@ -8,8 +8,6 @@ defmodule Exyt.Subscription do
   @parts     ["contentDetails", "id", "snippet", "subscriberSnippet"]
   @optionals ["forChannelId", "maxResults", "order", "pageToken"]
 
-  @order_method ["alphabetical", "relevance", "unread"]
-
   @type part     :: binary | atom
   @type filter   :: map()
   @type optional :: map()
@@ -39,8 +37,8 @@ defmodule Exyt.Subscription do
   def parse_arguments(part, filter, optional) do
     %{}
     |> Map.put("part", parse_part(part))
-    |> Map.merge(parse_options(filter, @filters))
-    |> Map.merge(parse_options(optional, @optionals))
+    |> Map.merge(parse(filter, @filters))
+    |> Map.merge(parse(optional, @optionals))
     |> Enum.sort()
   end
 
@@ -54,10 +52,13 @@ defmodule Exyt.Subscription do
     |> Enum.join(",")
   end
 
-  defp parse_options(opts, list) do
+  defp parse(opts, list) when is_list(opts) do
+    Enum.into(opts, %{}) |> parse(list)
+  end
+  defp parse(opts, list) when is_map(opts) do
     opts
     |> Enum.reduce(%{}, fn({k,v}, acc) -> Map.put(acc, to_string(k), v) end)
     |> Enum.filter(fn{k, _} -> Enum.member?(list, k) end)
-    |> Map.new()
+    |> Enum.into(%{})
   end
 end

--- a/test/exyt/subscription_test.exs
+++ b/test/exyt/subscription_test.exs
@@ -78,7 +78,7 @@ defmodule Exyt.SubscriptionTest do
       assert 200 == response.status_code
     end
 
-    test "accepts optional parameter forChannelId as list", %{client: client, bypass: bypass} do
+    test "accepts optional parameter forChannelId", %{client: client, bypass: bypass} do
       Bypass.expect_once bypass, "GET", "/subscriptions", fn conn ->
         assert conn.query_string == "channelId=lisa&forChannelId=test&part=id"
 
@@ -86,6 +86,19 @@ defmodule Exyt.SubscriptionTest do
       end
 
       {:ok, response} = Subject.list(client, :id, %{:channelId => "lisa"}, %{:forChannelId => "test"})
+
+      assert 200 == response.status_code
+    end
+
+    test "accepts optional parameter as list", %{client: client, bypass: bypass} do
+      Bypass.expect_once bypass, "GET", "/subscriptions", fn conn ->
+        assert conn.query_string == "channelId=lisa&maxResults=10&order=alphabetical&part=id"
+
+        json_response(conn, 200, "subscriptions.json")
+      end
+
+      optional = [{:maxResults, 10}, {:order, "alphabetical"}]
+      {:ok, response} = Subject.list(client, :id, %{:channelId => "lisa"}, optional)
 
       assert 200 == response.status_code
     end


### PR DESCRIPTION
Extend the current subscription endpoint and support `part`, `filter` and `optional` arguments as documented in the [Subscriptions#list](https://developers.google.com/youtube/v3/docs/subscriptions/list) API endpoint.

* allow atoms or strings for input values
* support keyword lists and maps as input arguments for `filter` and `optional`
* add tests to check how URL query is generated